### PR TITLE
chores: eslint/prettier config updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
     "no-console": "warn",
     "quotes": [
       "error",
-      "double",
+      "single",
       {
         "avoidEscape": true,
         "allowTemplateLiterals": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "singleQuote": true
 }


### PR DESCRIPTION
swapped double quotes for single in formatting/linting to align with airbnb, and bttn